### PR TITLE
Fix CUTLASS submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "flashdecoding/src/cutlass"]
 	path = flashdecoding/src/cutlass
-	url = https://github.com/NVIDIA/cutlass/tree/main
+	url = https://github.com/NVIDIA/cutlass.git


### PR DESCRIPTION
The previous URL was pointing to a GitHub tree page, which is not a valid Git repository URL. This commit updates the URL to the correct Git repository address to ensure proper submodule functionality.

New URL: https://github.com/NVIDIA/cutlass.git